### PR TITLE
Add .bat Files for Windows Use

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Timetrack
 
-- Timetrack is a simple commandline program for analysing your own Mac calendar data. 
-- The idea for this project was inspired by Devi Parikh's calendar-based time management technique (I highly recommend reading her blog post: https://blog.usejournal.com/calendar-in-stead-of-to-do-lists-9ada86a512dd). 
+- Timetrack is a simple commandline program for analysing your own Mac calendar data.
+- The idea for this project was inspired by Devi Parikh's calendar-based time management technique (I highly recommend reading her blog post: https://blog.usejournal.com/calendar-in-stead-of-to-do-lists-9ada86a512dd).
 - After experimenting with Devi's method for a while, I made some adaptations and developed Timetrack as part of my time management and productivity workflow.
 - If you are only interested in how to install and use Timetrack, feel free to skip to [Setup](##setup).
 
@@ -9,10 +9,10 @@
 
 ## Motivation
 
-### Calendar-based time management 
+### Calendar-based time management
 
 In her excellent blog post, Devi Parikh proposed to use a calender-based approach for time management instead of commonly used to-do lists (https://blog.usejournal.com/calendar-in-stead-of-to-do-lists-9ada86a512dd).
-The key idea is to schedule every task in your calendar (like you would do with a meeting) instead of keeping it on an ever-growing to-do list. This has the advantage of making the required time visible and making you think about how to best allocate it to certain tasks. I tried Devi's calendar-based time management system and really liked it. Its simple and effective. It requires you to break down large problems into more manageable chunks and encourages focusing on a single well-defined task at hand without getting distracted. 
+The key idea is to schedule every task in your calendar (like you would do with a meeting) instead of keeping it on an ever-growing to-do list. This has the advantage of making the required time visible and making you think about how to best allocate it to certain tasks. I tried Devi's calendar-based time management system and really liked it. Its simple and effective. It requires you to break down large problems into more manageable chunks and encourages focusing on a single well-defined task at hand without getting distracted.
 
 ### My adjustments
 
@@ -25,9 +25,9 @@ After trying this system for a couple of weeks, I made the following adjustments
 
 #### 1.  Keep separate calendars (and don’t move tasks to done calendar)
 
-In her blog post, Devi recommends using three calendars: ‘meetings’, ‘to-do’ and ‘done’ (there is also the ‘block’ calendar to reserve time for eating/sleeping/etc.). The idea is simple: place all new tasks in the ‘to-do’ calendar and then move them to the ‘done’ calendar once you’re finished. However, this doesn’t take into account that **tasks differ in importance and difficulty**. 
+In her blog post, Devi recommends using three calendars: ‘meetings’, ‘to-do’ and ‘done’ (there is also the ‘block’ calendar to reserve time for eating/sleeping/etc.). The idea is simple: place all new tasks in the ‘to-do’ calendar and then move them to the ‘done’ calendar once you’re finished. However, this doesn’t take into account that **tasks differ in importance and difficulty**.
 
-I therefore keep separate calendars for major vs. minor work-related tasks. Major tasks are tasks which will get you closer to your current professional goal. For example, if your main goal is to successfully complete your PhD, this could include tasks such as writing a paper, analysing data or writing code. Major tasks naturally tend to be relatively difficult and require high energy and focus. In contrast, minor tasks do not immediately contribute to your main goal, but still need to get done. These could include writing emails, planning your schedule for next week or reading a reading group paper unrelated to your own research. 
+I therefore keep separate calendars for major vs. minor work-related tasks. Major tasks are tasks which will get you closer to your current professional goal. For example, if your main goal is to successfully complete your PhD, this could include tasks such as writing a paper, analysing data or writing code. Major tasks naturally tend to be relatively difficult and require high energy and focus. In contrast, minor tasks do not immediately contribute to your main goal, but still need to get done. These could include writing emails, planning your schedule for next week or reading a reading group paper unrelated to your own research.
 In contrast to major tasks, minor tasks tend to require lower energy levels. **By placing major and minor tasks in different calendars, one look on your weekly schedule makes it immediately clear how important your tasks are and how long they will probably take.** This is useful information when it comes to optimally scheduling your tasks. For example, if you are more productive in the morning, this prime time should be reserved for working on your major tasks, while minor tasks can be deferred to after lunch when concentration levels and productivity tend to be lower.
 Although the feeling of moving a task from the ‘to-do’ to ‘done’ calendar can be rewarding, this action deletes valuable information regarding the task’s importance when analysing past calendar data (see point 3). Therefore, each task should be kept in its respective calendar after it’s done (see point 2 for what you should do instead after finishing a task). Tasks which are not work-related (e.g. working on a side project, eating, sleeping) go in the ‘life’ calendar, so they can be easily omitted during calendar analysis. You can also create additional calendars based on your personal needs (e.g. for travel or health/wellbeing).
 
@@ -48,7 +48,7 @@ At the end of the week, schedule a short weekly review task for Friday afternoon
 
 #### 4.  Analyse your calendar and productivity data with Timetrack
 
-By following this technique, your calendar will accumulate a large amount of valuable information over time. **Initially, you can simply look at your weekly calendar view to observe your working patterns, but as time progresses it becomes difficult to identify trends. That's why I wrote Timetrack.** Timetrack is a simple tool for analysing your calendar data. Its commandline interface allows you to adjust several settings, including which time periods and calendars to analyse (e.g. only major, minor and meetings). In the basic setting, the program reads your calendar data and summarises how much time you spent on which kind of task over a certain period of time to help you track your own progress. 
+By following this technique, your calendar will accumulate a large amount of valuable information over time. **Initially, you can simply look at your weekly calendar view to observe your working patterns, but as time progresses it becomes difficult to identify trends. That's why I wrote Timetrack.** Timetrack is a simple tool for analysing your calendar data. Its commandline interface allows you to adjust several settings, including which time periods and calendars to analyse (e.g. only major, minor and meetings). In the basic setting, the program reads your calendar data and summarises how much time you spent on which kind of task over a certain period of time to help you track your own progress.
 
 ```
 timetrack_multi_cal -calendars Major.ics,Minor.ics,Meeting.ics -start 2019-11-04 -end 2019-11-18 --all_days
@@ -80,11 +80,11 @@ export TIMETRACKDIR=/path/to/timetrack # e.g. Users/nicole/code/timetrack
 - Run timetrack.sh for easy commandline access to `multi_cal` and `single_cal`
 ```
 source timetrack.sh
-``` 
+```
 
 ## Usage
 
-- Now you can directly call `timetrack_multi_cal` or `timetrack_single_cal` from the commandline. 
+- Now you can directly call `timetrack_multi_cal` or `timetrack_single_cal` from the commandline.
 As the name suggest, `timetrack_single_cal` analyses data from a single calendar, while `timetrack_multi_cal` provides a summary for multiple calendars.
 Calendars and time interval are adjustable through commandline arguments:
 ```
@@ -149,3 +149,11 @@ optional arguments:
 
 ```
 
+## Use on Windows
+
+- To use on Windows, change '%TIMETRACKDIR' to the location of your timetrack folder in both `timetrack_multi_cal.bat` and `timetrack_single_cal.bat`.
+- Add the timetrack folder to the system path environment variables. This allows the use of `timetrack_multi_cal` and `timetrack_single_cal` from anywhere in the command line. On Windows 10, this is done via `Control Panel > System and Security > System > Advanced System Settings > Environment Variables`. Then double click on `Path` in System Variables then the `Browse...` button.
+
+All other setup and usage will be the same as above. How you export the .ics files depends on your calendar client.
+
+Note that these functions will *not* return you to the directory you began in but will move you to the timetrack folder.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,13 @@ export TIMETRACKDIR=/path/to/timetrack # e.g. Users/nicole/code/timetrack
 ```
 source timetrack.sh
 ```
+### Windows
+
+- To use on Windows, change '%TIMETRACKDIR' to the location of your timetrack folder in both `timetrack_multi_cal.bat` and `timetrack_single_cal.bat`.
+- Add the timetrack folder to the system path environment variables. This allows the use of `timetrack_multi_cal` and `timetrack_single_cal` from anywhere in the command line. On Windows 10, this is done via `Control Panel > System and Security > System > Advanced System Settings > Environment Variables`. Then double click on `Path` in System Variables then the `Browse...` button.
+
+All other setup and usage will be the same as above. How you export the .ics files depends on your calendar client.
+
 
 ## Usage
 
@@ -148,12 +155,3 @@ optional arguments:
                         Print time spent per calendar category per day.
 
 ```
-
-## Use on Windows
-
-- To use on Windows, change '%TIMETRACKDIR' to the location of your timetrack folder in both `timetrack_multi_cal.bat` and `timetrack_single_cal.bat`.
-- Add the timetrack folder to the system path environment variables. This allows the use of `timetrack_multi_cal` and `timetrack_single_cal` from anywhere in the command line. On Windows 10, this is done via `Control Panel > System and Security > System > Advanced System Settings > Environment Variables`. Then double click on `Path` in System Variables then the `Browse...` button.
-
-All other setup and usage will be the same as above. How you export the .ics files depends on your calendar client.
-
-Note that these functions will *not* return you to the directory you began in but will move you to the timetrack folder.

--- a/src/multi_calendar.py
+++ b/src/multi_calendar.py
@@ -1,7 +1,7 @@
-from src.single_calendar import *
+from single_calendar import *
 from datetime import timedelta
-from src.plotting import plot_multi_cal_time
-from src.helpers import get_prod_by_date
+from plotting import plot_multi_cal_time
+from helpers import get_prod_by_date
 
 class MultiCalendar:
 

--- a/src/single_calendar.py
+++ b/src/single_calendar.py
@@ -1,4 +1,4 @@
-from src.helpers import read_calendar,get_total_time,convert_dt,get_today,get_last_week,get_last_month,get_tomorrow,get_avg_productivity,get_timerange_str,get_time_by_date
+from helpers import read_calendar,get_total_time,convert_dt,get_today,get_last_week,get_last_month,get_tomorrow,get_avg_productivity,get_timerange_str,get_time_by_date
 import argparse
 import warnings
 
@@ -69,4 +69,3 @@ if __name__ == '__main__':
     major_cal = Calendar(cal_path,FLAGS.start,FLAGS.end,FLAGS.today,FLAGS.this_week,FLAGS.this_month)
     major_cal.print_components()
     major_cal.get_time_summary()
-

--- a/timetrack_multi_cal.bat
+++ b/timetrack_multi_cal.bat
@@ -1,9 +1,10 @@
 @echo OFF
-SET %TIMETRACKDIR=\Users\nicole\code\timetrack
+SET TIMETRACKDIR=\Users\nicole\code\timetrack
+SET PREVDIR=%CD%
 
 :timetrack_multi_cal
 CALL cd %TIMETRACKDIR%
-ECHO %CD%
 CALL python src\multi_calendar.py %*
+CALL cd %PREVDIR%
 PAUSE
 EXIT /B 0

--- a/timetrack_multi_cal.bat
+++ b/timetrack_multi_cal.bat
@@ -1,0 +1,9 @@
+@echo OFF
+SET %TIMETRACKDIR=\Users\nicole\code\timetrack
+
+:timetrack_multi_cal
+CALL cd %TIMETRACKDIR%
+ECHO %CD%
+CALL python src\multi_calendar.py %*
+PAUSE
+EXIT /B 0

--- a/timetrack_single_cal.bat
+++ b/timetrack_single_cal.bat
@@ -1,0 +1,9 @@
+@echo OFF
+SET %TIMETRACKDIR=\Users\nicole\code\timetrack
+
+:timetrack_single_cal
+CALL cd %TIMETRACKDIR%
+ECHO %CD%
+CALL python src\single_calendar.py %*
+PAUSE
+EXIT /B 0

--- a/timetrack_single_cal.bat
+++ b/timetrack_single_cal.bat
@@ -1,9 +1,10 @@
 @echo OFF
-SET %TIMETRACKDIR=\Users\nicole\code\timetrack
+SET TIMETRACKDIR=\Users\nicole\code\timetrack
+SET PREVDIR=%CD%
 
 :timetrack_single_cal
 CALL cd %TIMETRACKDIR%
-ECHO %CD%
 CALL python src\single_calendar.py %*
+CALL cd %PREVDIR%
 PAUSE
 EXIT /B 0


### PR DESCRIPTION
To be able use timetrack on Windows, I've created some quick .bat files to replace the .sh file for Unix systems and added a section to the README. This is my first time writing batch scripts so there will definitely be some improvements to be made! Just in case they are useful for others. I also had to remove the `src.` from the `from src.single_calendar ..., from src.plotting ... , from src.helpers ..` lines in `multi_calendar.py` and `single_calendar.py`. I've left that off this pull request as I can't test if the same change is necessary on Mac.

Thanks for creating a great tool! 